### PR TITLE
Chnaged listing files created; Added barcode prompt

### DIFF
--- a/single-cd.sh
+++ b/single-cd.sh
@@ -175,8 +175,8 @@ else
 fi
 
 echo
-echo "${dir} listing:"
-ls -lh ${dir}
+echo "Files just created in ${dir}"
+find ${dir} -type f -name "${diskID}.*"
 echo
 
 rm tmp.json

--- a/single-cd.sh
+++ b/single-cd.sh
@@ -178,6 +178,10 @@ echo
 echo "Files just created in ${dir}"
 find ${dir} -type f -name "${diskID}.*"
 echo
+if [[ $barcode != "" ]]; then
+    echo "Item Barcode is: ${barcode}"
+fi
+echo
 
 rm tmp.json
 

--- a/single-cd.sh
+++ b/single-cd.sh
@@ -175,7 +175,7 @@ else
 fi
 
 echo
-echo "Files just created in ${dir}"
+echo "Files just created in ${dir} :"
 find ${dir} -type f -name "${diskID}.*"
 echo
 if [[ $barcode != "" ]]; then


### PR DESCRIPTION
1. Changed from listing all files in the directory to listing the file with the $diskID only.
2. If the barcode exists, show the item barcode number before the script ends.