### PR TITLE
Audio disc support + multiple disc dirves imaging

### DIFF
--- a/single-cd.sh
+++ b/single-cd.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+
 # bash
 #@jesswhyte, rewrite of single-cd.sh/single-barcode.sh/single-cd-nocall.sh, from 2016
+#@kenlhlui, added the support of audio discs imaging by using abcde package in June 2023
 
 function show_help() {
 	echo
@@ -9,14 +11,17 @@ function show_help() {
 	echo -o ": The directory you want to output to, e.g. /mnt/data/"
     echo -m ": MMSID e.g. alma991105954773306196, optional"
     echo -b ": item barcode, e.g. 31761095831004, optional"
-    echo -d ": Disk ID, e.g. B2014-004-001, B2014-004-002, optional"
+    echo -d ": Disc ID, e.g. B2014-004-001, B2014-004-002, optional"
     echo -N ": boolean flag for multiple disks in object"
  	echo -J ": boolean flag for if object is part of a journal or series"
+    echo -R ": Disc Drive path. Built-in drive = /dev/sr0, USB drive(s) = /dev/sr1(..2..), optional"
+    echo -Y ": Process imgaging, scanning and pulling metadata without extra confirmation"
     echo
     echo -e "Example:\n./single-cd.sh -l ECSL -o /mnt/data/ -m alma991105954773306196"  
 	echo 
 }
 
+audio=false
 multiple=false
 journal=false
 OPTIND=1
@@ -26,14 +31,16 @@ lib=""
 diskID=""
 barcode=""
 MMSID=""
-drive="/dev/cdrom"
+start_datetime=$(date +"%Y%m%d%H%M%S")
+#random_num=$((1 + RANDOM % 100000000))
+fullsteps=false
 
 # Parse arguments
-while getopts "h?o:l:m:b:d:NJ" opt; do
+while getopts "h?D:o:l:m:b:d:NJ:Y" opt; do
     case "$opt" in
     h|\?)
         show_help
-	exit
+	    exit
         ;;
     o)  dir=$OPTARG
         ;;
@@ -45,9 +52,14 @@ while getopts "h?o:l:m:b:d:NJ" opt; do
         ;;
     d)  diskID=$OPTARG
         ;;
+    D)  drive=$OPTARG
+        ;;
     N)  multiple=true
         ;;
     J)  journal=true
+        ;;
+    Y)  fullsteps=true
+        ;;
     esac
 done
 
@@ -65,35 +77,40 @@ elif [ -z "$dir" ]; then
   exit 	
 fi
 
-# ask if there are multiple disks
+# Ask if there are multiple disks
 if $multiple; then
     echo
     IFS= read -re -p 'Multiple discs: Which Disc # is this, e.g. 001, 002, 003? ' disknum
     echo
 fi
 
+# Specify default disc-drive if blank
+if [ -z "$drive" ]; then
+    drive="/dev/sr0"
+fi
+
 #### GET diskID, the FILENAME, based on callnumber or provided diskID ###
 
 if [[ $barcode != "" ]]; then
-    bash barcode-pull.sh -b ${barcode} -f > tmp.json
+    bash barcode-pull.sh -b ${barcode} -f > tmp_${start_datetime}.json
     echo "Using barcode: ${barcode}"
     if $journal; then 
         echo "JOURNAL OR SERIES identified by -J. Using item_data.alternative_call_number"
-        diskID=$(jq -r .item_data.alternative_call_number tmp.json)
+        diskID=$(jq -r '.item_data.alternative_call_number' "tmp_${start_datetime}.json")
     else
-        diskID=$(jq -r .holding_data.permanent_call_number tmp.json)
+        diskID=$(jq -r '.holding_data.permanent_call_number' "tmp_${start_datetime}.json")
     fi
     echo "callNumber=${diskID}"
 elif [[ $MMSID != "" ]]; then 
-    bash mmsid-pull.sh -m ${MMSID} -f > tmp.json
+    bash mmsid-pull.sh -m "${MMSID}" -f > "tmp_${start_datetime}.json"
     echo "Using MMSID: ${MMSID}"
-    diskID=$(jq -r .delivery.bestlocation.callNumber tmp.json)
+    diskID=$(jq -r '.delivery.bestlocation.callNumber' "tmp_${start_datetime}.json")
     echo "callNumber=${diskID}"
 elif [[ $diskID != "" ]]; then
     echo "Using: ${diskID}" # this is a placeholder
 fi
 
-#diskID="${diskID^^// /-//./-//--/-//\"}" # replace spaces, dots and double dashes with single dashes, remove double quotes
+#Replace spaces, dots and double dashes with single dashes, remove double quotes
 diskID=${diskID// /-}
 diskID=${diskID//./-}
 diskID=${diskID^^}
@@ -102,106 +119,177 @@ diskID=${diskID//\"/}
 echo "diskID=${diskID}"
 
 if [[ -n "$disknum" ]]; then
-	diskID="${diskID}-DISK_${disknum}"
+    diskID="${diskID}-DISK_${disknum}"
 fi
-	
 	
 echo ""
 read -p "Please insert disc into drive and hit Enter"
 echo
-read -p "Please hit Enter again, once disc is fully LOADED"
+read -p "Please hit Enter again, once the disc is fully LOADED"
 echo
 
 #get CD INFO
-cdinfo=$(isoinfo -d -i /dev/cdrom)
+cdinfo=$(isoinfo -d -i $drive)
 volumeCD=$(echo "$cdinfo" | grep "^Volume id:" | cut -d " " -f 3)
 #get blockcount/volume size of CD
 blockcount=$(echo "$cdinfo" | grep "^Volume size is:" | cut -d " " -f 4)
 if test "$blockcount" = ""; then
-	echo
-	echo FAIL: catdevice FATAL ERROR: Blank blockcount >&2
-	#exit 2
+    echo
+    echo "FAIL: catdevice FATAL ERROR: Blank blockcount" >&2
+    #exit 2
 fi
 
 #get blocksize of CD
 blocksize=$(echo "$cdinfo" | grep "^Logical block size is:" | cut -d " " -f 5)
 if test "$blocksize" = ""; then
-	echo
-	echo FAIL: catdevice FATAL ERROR: Blank blocksize >&2
-	#exit 2
+    echo
+    echo "FAIL: catdevice FATAL ERROR: Blank blocksize" >&2
+    #exit 2
 fi
 
+#### Audio CD #####
+if test "$blocksize" = ""; then
+    echo
+    echo
+    echo
+    echo
+    tracknum=$(cdrdao disk-info -v 0 --device "$drive" | grep "Last Track" | grep -o '[0-9]\+')
+    if test $tracknum != ""; then
+        audio=true 
+        dir="${dir}${diskID}"
+        echo "The disc is an audio disc. A directory will be created for the audio tracks: ${dir}"
+        echo
+        echo "There are ${tracknum} audio tracks in this disc"
+        echo
+        mkdir -p "$dir"
+        touch "$dir/abcde.conf"
+        echo "WAVOUTPUTDIR=${dir}" >> "${dir}/abcde.conf"
+        abcde -c "$dir/abcde.conf" -d "$drive" -a read
+        mv "$dir"/*/*.wav "$dir"
+        mv "$dir"/*/status "$dir/${diskID}.log"
+        rm -rf "$dir"/*/
+        rm "$dir/abcde.conf"       
+    fi
+    #exit 2
+else
+
 ##### Display CD INFO #####
-echo ""
-echo "Volume label for CD is: "$volumeCD
-echo "Volume size for CD is: "$blockcount
-echo 
-dir=${dir%/}
-mkdir -p $dir
+    echo ""
+    echo "Volume label for CD is: "$volumeCD
+    echo "Volume size for CD is: "$blockcount
+    echo 
+    dir=${dir%/}
+    mkdir -p $dir
 
 #### RIP ISO #####
-echo "Ripping CD to ${dir}/${diskID}.iso"
-echo
-dd bs=${blocksize} count=${blockcount} if=/dev/cdrom of=${dir}/${diskID}.iso status=progress
-
+    echo "Ripping CD to ${dir}/${diskID}.iso"
+    echo
+    dd bs=${blocksize} count=${blockcount} if=$drive of=${dir}/${diskID}.iso status=progress
+fi
 
 ##### SCANNING CD #####
 echo
-read -p "Do you want to scan this disc? [y/n] " response
-if [[ "$response" =~ ^([Yy])+$ ]]; then
-	echo "Ejecting drive..."
-	eject
-	read -p "Please put disc on scanner and hit any key when ready"
-    bash justscan.sh -d $dir -c ${diskID}
-else
-    echo "skipping scanning disc"
+echo
+if [[ $fullsteps == true ]]; then
+    response=Y
+else 
+    read -p "Do you want to scan this disc? [y/n] " response
 fi
 
-checksum=$(md5sum ${dir}/${diskID}.iso | cut -d ' ' -f 1) # Generate md5 checksum for iso files
+if [[ $response =~ ^([Yy])+$ ]]; then
+    echo "Ejecting drive..."
+    eject $drive
+    read -p "Please put disc on the scanner and hit any key when ready"
+    bash justscan.sh -d $dir -c ${diskID}
+else
+    echo "Skipping scanning the disc"
+fi
+
 
 #### Pulling metadata #####
 echo
-read -p "Do you want to pull the catalog metadata for this disk [y/n] " metaresponse 
-if [[ "${metaresponse}" =~ ^([Yy])+$ ]]; then
+if [[ $fullsteps == true ]]; then
+    metaresponse=Y
+else 
+    read -p "Do you want to pull the catalog metadata for this disk [y/n] " metaresponse 
+fi
+
+if [[ $metaresponse =~ ^([Yy])+$ ]]; then
     if [[ $barcode != "" ]]; then
-        MMSID=$(jq -r .bib_data.mms_id tmp.json)
-        bash mmsid-pull.sh -m alma${MMSID} -f > tmp.json
-        jq -r '.pnx | del(.delivery,.display.source,.display.crsinfo)' tmp.json > ${dir}/${diskID}.json
-    elif [[ $MMSID != "" ]]; then 
-        jq -r '.pnx | del(.delivery,.display.source,.display.crsinfo)' tmp.json > ${dir}/${diskID}.json
+        MMSID=$(jq -r .bib_data.mms_id tmp_$start_datetime.json)
+        bash mmsid-pull.sh -m alma${MMSID} -f > tmp_$start_datetime.json
+        jq -r '.pnx | del(.delivery,.display.source,.display.crsinfo)' tmp_$start_datetime.json > ${dir}/${diskID}.json
+    elif [[ $MMSID != "" ]]; then
+        jq -r '.pnx | del(.delivery,.display.source,.display.crsinfo)' tmp_$start_datetime.json > ${dir}/${diskID}.json
     else
-        echo "no barcode or MMSID provided to pull metadata."
+        echo "No barcode or MMSID provided to pull metadata."
     fi
 else
-    echo "skipping metadata pull"
+    echo "Skipping metadata pull"
 fi
-#### Showing the created file(s) and item barcode #####
-echo
-echo "Files just created in ${dir} :"
-find ${dir} -type f -name "${diskID}.*"
-echo
-if [[ $barcode != "" ]]; then
-    echo "Item Barcode is: ${barcode}"
-fi
-echo
 
-#### Creating projectlog.csv #####
+##### Variables for projectlog #####
 projectlog="${dir}/projectlog.csv"
 isofile=$(find ${dir} -type f -name "${diskID}.iso" -printf "%f\n")
 tifffile=$(find ${dir} -type f -name "${diskID}.tiff" -printf "%f\n")
 jsonfile=$(find ${dir} -type f -name "${diskID}.json" -printf "%f\n")
+checksum=$(md5sum ${dir}/${diskID}.iso | cut -d ' ' -f 1) # Generate md5 checksum for iso files
 dateNtime=$(date +"%Y%m%d_%H%M%S")
-
-header="diskID,barcode,iso_file,tiff_file,json_file,iso_checksum,create_time" #csv header
-if [ ! -f "$projectlog" ]; then #check if the file exists; if not, add the header
-    echo "$header" > "$projectlog"
-fi
-
+projectlog_audio="$(dirname "${dir}")/projectlog_audio.csv"
+track_no=$(find ${dir} -type f -name "*.wav" | wc -l)
+abcdelog=$(find ${dir} -type f -name "${diskID}.log" -printf "%f\n")
 title=$(jq -r '.display.title | @text' ${dir}/${jsonfile})
 
-echo "Item title: ${title}"
-echo "${diskID},${barcode},${isofile},${tifffile},${jsonfile},${checksum},${dateNtime}" >> ${projectlog}
-echo
-echo "See the updated projectlog in ${projectlog}"
+##### Creating non-audio disc projectlog.csv #####
+if [[ $audio == false ]]; then
+    header="diskID,barcode,iso_file,tiff_file,json_file,iso_checksum,create_time" # Creating projectlog.csv header
+    if [ ! -f "$projectlog" ]; then # Check if the file exists; if not, add the header
+        echo "$header" > "$projectlog"
+    fi
 
-rm tmp.json
+    echo "Item title: ${title}"
+    echo
+    if [[ $barcode != "" ]]; then
+        echo "The item barcode is: ${barcode}"
+        echo
+    fi
+    echo "${diskID},${barcode},${isofile},${tifffile},${jsonfile},${checksum},${dateNtime}" >> "${projectlog}"
+    echo
+    echo "Files just created in ${dir}:"
+    find $dir -type f -name "${diskID}.*"
+    echo
+    echo "See the updated projectlog in ${projectlog}"
+##### Creating audio disc projectlog.csv #####
+else
+    header="diskID,barcode,total_tracks,tiff_file,json_file,abcde_log,create_time" # Creating projectlog_audio.csv header
+    if [ ! -f "$projectlog_audio" ]; then # Check if the file exists; if not, add the header
+        echo "$header" > "$projectlog_audio"
+    fi
+
+    echo
+    echo "Item title: ${title}"
+    if [[ $barcode != "" ]]; then
+        echo "The item barcode is: ${barcode}"
+        echo
+    fi
+    echo "${diskID},${barcode},${track_no},${tifffile},${jsonfile},${abcdelog},${dateNtime}" >> "${projectlog_audio}"
+    echo
+    echo "Directory just created:"
+    echo "${dir}"
+    echo
+    if [ $(find $dir -name "track*.wav" | wc -l) == $tracknum ]; then
+        echo "The number of tracks in the directory matches the one in the disc"
+    else
+        echo "The number of tracks in the directory does not match the one in the disc. PLEASE CHECK THE IMAGING COMPLETENESS."
+    fi
+    #echo "The disc contains ${tracknum} audio files."
+    #echo "The directory contains $(find $dir -type f *.wav | wc -l) files"
+    echo
+    echo "See the following log files:"
+    find $dir -type f -name "${diskID}.*"
+    echo
+    echo "See the updated projectlog_audio in ${projectlog_audio}"
+fi
+
+# Remove temporary file
+rm "tmp_${start_datetime}.json"


### PR DESCRIPTION
1. Added audio disc imaging support: extract audio tracks by abcde package; showing the tracks in the disc;  Checking the sameness of the number of disc tracks and the the exported directory tracks; separating audio disc log (projectlog_audio.csv)
2. Added -Y flag: indicating full steps (imaging, scanning and pull metadata), skipping all the confirmation prompts for scanning and pulling metadata
3. Added -D flag: indicating a specific disc drive for disc imaging
4. Changed the name of tmp.json to tmp_{datetime}.json, for multiple disc imaging sessions
5. Fixed some spellings and comment formats